### PR TITLE
Docs: Fix Links and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,18 @@
 
 ## Introduction
 
-The typo3 extension for the easy plug 'n play solution for legal compliance of legal web.
+The TYPO3 extension for the easy plug 'n play solution for legal compliance of legal web.
 
 ## Getting started
-1. Install the extension with your Typo3 extension manager. Search for "legal web typo3"
+
+1. Install the extension with your TYPO3 extension manager. Search for "legal web typo3"
 2. [Obtain your license](https://legalweb.io)
-3. Add the plugin constants to the template constants to manage it with the Typo3 constant editor [according to this manual] (https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/UsingSetting/Entering.html#static-includes)
-4. Configure the typoscript parameters to set GUID and enabling the cookie popup (PLUGIN.TX_LEGALWEBTYPO3_PI1)
+3. Add the plugin constants to the template constants to manage it with the TYPO3 constant editor [according to this manual](https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/UsingSetting/Entering.html#static-includes)
+4. Configure the typoscript parameters to set `GUID` and enabling the cookie popup (`PLUGIN.TX_LEGALWEBTYPO3_PI1`)
 5. Add Content Elements to your page to render imprint, privacy policy and more
-   
+
 ## Troubles/Feedback
-Please [create an issue](https://github.com/legalwebio/legalweb-typo3/issues/new) if you have any troubles with the plugin or would like to give us any feedback. Thanks! 
+
+Please [create an issue](https://github.com/legalwebio/legalweb-typo3/issues/new) if you have any troubles with the plugin or would like to give us any feedback. Thanks!
+
+


### PR DESCRIPTION
* Fix Link to manual
* Fix wording of TYPO3 (All uppercase)
  * https://typo3.org/project/brand/spelling-typo3